### PR TITLE
🧹 optimize: move static location filtering outside CrystalBall component

### DIFF
--- a/views/CrystalBall.tsx
+++ b/views/CrystalBall.tsx
@@ -6,6 +6,11 @@ import { NavLink } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { NolaLocation } from '../types';
 
+const NHEN_NAMES_SET = new Set(NHEN_PICK_NAMES);
+const CANDIDATE_LOCATIONS = LOCATIONS.filter(loc =>
+  NHEN_NAMES_SET.has(loc.name)
+);
+
 export const CrystalBall: React.FC = () => {
   const [prediction, setPrediction] = useState<NolaLocation | null>(null);
   const [isGazing, setIsGazing] = useState(false);
@@ -17,13 +22,8 @@ export const CrystalBall: React.FC = () => {
     
     // Simulate gazing time
     setTimeout(() => {
-      // Filter LOCATIONS to match ONLY names in NHEN_PICK_NAMES
-      const candidateLocations = LOCATIONS.filter(loc => 
-        NHEN_PICK_NAMES.includes(loc.name)
-      );
-      
-      if (candidateLocations.length > 0) {
-        const randomPick = candidateLocations[Math.floor(Math.random() * candidateLocations.length)];
+      if (CANDIDATE_LOCATIONS.length > 0) {
+        const randomPick = CANDIDATE_LOCATIONS[Math.floor(Math.random() * CANDIDATE_LOCATIONS.length)];
         setPrediction(randomPick);
       }
       


### PR DESCRIPTION
**🎯 What:** Optimized `CrystalBall` component by moving the static filtering of `LOCATIONS` outside the component and using a `Set` for efficient lookups.
**💡 Why:** Prevents unnecessary repeated array filtering every time the "gaze into crystal" action is triggered, improving performance and readability.
**✅ Verification:** Manually verified the refactoring via code inspection. Attempted to run tests and build, but the environment lacks the necessary dependencies and internet access to install them.
**✨ Result:** Pre-computed `CANDIDATE_LOCATIONS` constant and more efficient O(N) filtering logic.

---
*PR created automatically by Jules for task [14870072948364589901](https://jules.google.com/task/14870072948364589901) started by @nhenia*