### PR TITLE
🧪 Add error path tests for getLocationProphecy

### DIFF
--- a/services/gemini.test.ts
+++ b/services/gemini.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getLocationProphecy } from './gemini';
+import { GoogleGenAI } from '@google/genai';
+
+vi.mock('@google/genai', () => {
+  const generateContent = vi.fn();
+  return {
+    GoogleGenAI: vi.fn().mockImplementation(() => ({
+      models: {
+        generateContent,
+      },
+    })),
+  };
+});
+
+describe('getLocationProphecy', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it('returns a prophecy on success', async () => {
+    process.env.GEMINI_API_KEY = 'test-api-key';
+    const mockResponse = { text: 'The neon fog lifts, revealing a path of gold.' };
+
+    // Get the mocked class and instance
+    const MockGoogleGenAI = vi.mocked(GoogleGenAI);
+    const mockAI = new MockGoogleGenAI({ apiKey: 'test' });
+    vi.mocked(mockAI.models.generateContent).mockResolvedValue(mockResponse as any);
+
+    const result = await getLocationProphecy('Jackson Square', 'The Star');
+
+    expect(result).toBe('The neon fog lifts, revealing a path of gold.');
+    expect(MockGoogleGenAI).toHaveBeenCalledWith({ apiKey: 'test-api-key' });
+  });
+
+  it('returns fallback string when response has no text', async () => {
+    process.env.GEMINI_API_KEY = 'test-api-key';
+    const MockGoogleGenAI = vi.mocked(GoogleGenAI);
+    const mockAI = new MockGoogleGenAI({ apiKey: 'test' });
+    vi.mocked(mockAI.models.generateContent).mockResolvedValue({ text: '' } as any);
+
+    const result = await getLocationProphecy('Jackson Square', 'The Star');
+
+    expect(result).toBe('The spirits are silent, but the neon hums your name.');
+  });
+
+  it('returns error fallback when generateContent throws', async () => {
+    process.env.GEMINI_API_KEY = 'test-api-key';
+    const MockGoogleGenAI = vi.mocked(GoogleGenAI);
+    const mockAI = new MockGoogleGenAI({ apiKey: 'test' });
+    vi.mocked(mockAI.models.generateContent).mockRejectedValue(new Error('API Error'));
+
+    // Suppress console.error for this test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await getLocationProphecy('Jackson Square', 'The Star');
+
+    expect(result).toBe('The veil is thin; seek the truth within the shadows.');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('returns silent fallback when API key is missing', async () => {
+    delete process.env.GEMINI_API_KEY;
+    const result = await getLocationProphecy('Jackson Square', 'The Star');
+    expect(result).toBe('The spirits are silent, but the neon hums your name.');
+  });
+});

--- a/services/gemini.ts
+++ b/services/gemini.ts
@@ -1,12 +1,11 @@
-
 import { GoogleGenAI } from "@google/genai";
 
-const apiKey = process.env.GEMINI_API_KEY || "";
-const ai = apiKey ? new GoogleGenAI({ apiKey }) : null;
-
 export async function getLocationProphecy(locationName: string, arcana: string): Promise<string> {
-  if (!ai) return "The spirits are silent, but the neon hums your name.";
+  const apiKey = process.env.GEMINI_API_KEY || "";
+  if (!apiKey) return "The spirits are silent, but the neon hums your name.";
+
   try {
+    const ai = new GoogleGenAI({ apiKey });
     const response = await ai.models.generateContent({
       model: 'gemini-3-flash-preview',
       contents: `You are an occult guide to New Orleans. Write a short, cryptic, poetic "spiritual reading" (2 sentences max) for a tourist visiting ${locationName}, which is associated with ${arcana} Tarot card. Use witchy, glitchy language, neon-noir metaphors, and techno-occult terminology. Ensure the tone is evocative and mysterious.`,


### PR DESCRIPTION
The `getLocationProphecy` function lacked tests for its error paths. I have refactored the service to be more testable and added a comprehensive Vitest suite that covers success, empty responses, API rejections, and missing credentials. This ensures the application remains resilient and always returns a valid (fallback) prophecy to the user even if the AI service fails.

---
*PR created automatically by Jules for task [17725107823571184150](https://jules.google.com/task/17725107823571184150) started by @nhenia*