### PR TITLE
🔒 Prevent sensitive data exposure in Gemini error logs

### DIFF
--- a/services/gemini.test.ts
+++ b/services/gemini.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, mock, spyOn } from 'bun:test';
+
+// Set environment variable BEFORE ANY IMPORTS that might use it
+process.env.GEMINI_API_KEY = 'test-api-key';
+
+// Mocking before import
+mock.module('@google/genai', () => {
+  return {
+    GoogleGenAI: class {
+      constructor() {
+        process.stdout.write('GoogleGenAI constructor called\n');
+      }
+      get models() {
+        return {
+          generateContent: async () => {
+            process.stdout.write('generateContent called\n');
+            const err = new Error('Some error message');
+            (err as any).stack = 'Error: Some error\n at sensitiveFunction (/path/to/secret/file.ts:123:45)\n SecretKey: 12345';
+            (err as any).config = {
+              headers: {
+                Authorization: 'Bearer 12345'
+              }
+            };
+            throw err;
+          }
+        };
+      }
+    }
+  };
+});
+
+import { getLocationProphecy } from './gemini';
+
+describe('getLocationProphecy Security Fix', () => {
+  it('should not leak sensitive information in console.error', async () => {
+    const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    process.stdout.write('Calling getLocationProphecy\n');
+    const result = await getLocationProphecy('Jackson Square', 'The Star');
+    process.stdout.write(`Result: ${result}\n`);
+
+    expect(consoleSpy).toHaveBeenCalled();
+
+    const firstCallArgs = consoleSpy.mock.calls[0];
+    const combinedArgs = firstCallArgs.map(arg =>
+      typeof arg === 'object' ? JSON.stringify(arg) : String(arg)
+    ).join(' ');
+
+    const hasSecret = combinedArgs.includes('SecretKey') || combinedArgs.includes('Bearer');
+
+    if (hasSecret) {
+        process.stdout.write('Verification: Sensitive information found in logs as expected (VULNERABLE)\n');
+    } else {
+        process.stdout.write('Verification: Sensitive information NOT found in logs\n');
+    }
+
+    // It should contain the error message but not the full object/stack
+    expect(combinedArgs).toContain('Some error message');
+    expect(combinedArgs).not.toContain('SecretKey');
+    expect(combinedArgs).not.toContain('Bearer');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/services/gemini.ts
+++ b/services/gemini.ts
@@ -1,10 +1,13 @@
 
 import { GoogleGenAI } from "@google/genai";
 
-const apiKey = process.env.GEMINI_API_KEY || "";
-const ai = apiKey ? new GoogleGenAI({ apiKey }) : null;
+const getAI = () => {
+  const apiKey = process.env.GEMINI_API_KEY || "";
+  return apiKey ? new GoogleGenAI({ apiKey }) : null;
+};
 
 export async function getLocationProphecy(locationName: string, arcana: string): Promise<string> {
+  const ai = getAI();
   if (!ai) return "The spirits are silent, but the neon hums your name.";
   try {
     const response = await ai.models.generateContent({
@@ -15,9 +18,10 @@ export async function getLocationProphecy(locationName: string, arcana: string):
         topP: 0.95,
       }
     });
-    return response.text || "The spirits are silent, but the neon hums your name.";
-  } catch (error) {
-    console.error("Gemini Error:", error);
+    return (response as any).text || "The spirits are silent, but the neon hums your name.";
+  } catch (error: any) {
+    const errorMessage = error instanceof Error ? error.message : "An error occurred during the request.";
+    console.error("Gemini Error:", errorMessage);
     return "The veil is thin; seek the truth within the shadows.";
   }
 }


### PR DESCRIPTION
### 🔒 [security fix description]

🎯 **What:** The vulnerability fixed was the potential exposure of sensitive data in console logs within the `getLocationProphecy` function in `services/gemini.ts`.

⚠️ **Risk:** If left unfixed, an error from the Google Gemini API could include sensitive information such as API keys, authorization tokens, or internal file paths in its error object. By logging the entire object with `console.error("Gemini Error:", error)`, this sensitive data would be written to the browser console or server logs, where it could be accessed by unauthorized parties or malicious actors.

🛡️ **Solution:** The fix replaces the logging of the full error object with a more restricted log that only outputs the error message (`error.message`). This ensures that the technical details of the error are captured for debugging without exposing the internal state or secrets of the API request. Additionally, the service was refactored to better support the 'Bring Your Own Key' model and has been verified with a new test suite that mocks sensitive error responses.

---
*PR created automatically by Jules for task [18157352774209451266](https://jules.google.com/task/18157352774209451266) started by @nhenia*